### PR TITLE
Add missing entry point pyFAI-diffmap-view

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [python_impl == "pypy"]
   entry_points:
     - check_calib = pyFAI.app.check_calib:main
@@ -32,7 +32,7 @@ build:
     - pyFAI-drawmask = pyFAI.app.drawmask:main
     - pyFAI-diffmap = pyFAI.app.diff_map:main
     - pyFAI-integrate = pyFAI.app.integrate:main
-
+    - pyFAI-diffmap-view = pyFAI.app.pilx:main
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

`pyFAI-diffmap-view` entry point was missing from the list

Related to https://github.com/silx-kit/pyFAI/issues/2439